### PR TITLE
Removing PPR for simplicity.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,12 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  experimental: {
-    ppr: true,
-  },
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'avatars.githubusercontent.com',
-        port: '',
-        pathname: '/u/**',
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        port: "",
+        pathname: "/u/**",
       },
     ],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,10 @@ module.exports = {
   images: {
     remotePatterns: [
       {
-        protocol: "https",
-        hostname: "avatars.githubusercontent.com",
-        port: "",
-        pathname: "/u/**",
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/u/**',
       },
     ],
   },


### PR DESCRIPTION
PPR adds a dynamic content blink. Removing it looks better and serves the point of the template better.