### PR TITLE
remove ppr

### DIFF
--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -1,11 +1,11 @@
-import Image from 'next/image';
-import { Marked } from 'marked';
-import { markedHighlight } from 'marked-highlight';
-import hljs from 'highlight.js';
-import styles from '../../styles/Home.module.scss';
-import { fetchIssuePageData } from '../../lib/github';
-import avatar from '../avatar.png';
-import { Time } from '../time-ago';
+import Image from "next/image";
+import { Marked } from "marked";
+import { markedHighlight } from "marked-highlight";
+import hljs from "highlight.js";
+import styles from "../../styles/Home.module.scss";
+import { fetchIssuePageData } from "../../lib/github";
+import avatar from "../avatar.png";
+import { Time } from "../time-ago";
 
 interface Comment {
   html_url: string;
@@ -18,36 +18,54 @@ interface Comment {
   body: string;
 }
 
-function markdownToHtml(markdown: string) {
+export function generateStaticParams() {
+  return [];
+}
+
+function markdownToHtml(
+  markdown: string
+) {
   if (!markdown) {
-    return '';
+    return "";
   }
 
   const marked = new Marked(
     markedHighlight({
-      langPrefix: 'hljs language-',
+      langPrefix: "hljs language-",
       highlight(code, lang) {
-        const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-        return hljs.highlight(code, { language }).value;
-      }
+        const language =
+          hljs.getLanguage(lang)
+            ? lang
+            : "plaintext";
+        return hljs.highlight(code, {
+          language,
+        }).value;
+      },
     })
   );
 
-  return marked.parse(markdown) as string;
+  return marked.parse(
+    markdown
+  ) as string;
 }
 
 export default async function IssuePage({
-  params
+  params,
 }: {
   params: Promise<{ id: string }>;
 }) {
   const id = (await params).id;
-  const { issue, comments } = await fetchIssuePageData(id);
+  const { issue, comments } =
+    await fetchIssuePageData(id);
 
   // Filter out comments that contain "bot" in the title
-  const filteredComments = comments.filter(
-    (comment) => !comment.user.login.toLowerCase().includes('bot')
-  );
+  const filteredComments =
+    comments.filter(
+      (comment) =>
+        !comment.user.login
+          .toLowerCase()
+          .includes("bot")
+    );
 
   return (
     <div className={styles.comments}>
@@ -61,56 +79,104 @@ export default async function IssuePage({
         <div className={styles.image}>
           <Image
             alt={issue.user.login}
-            src={issue.user?.avatar_url || avatar}
+            src={
+              issue.user?.avatar_url ||
+              avatar
+            }
             className={styles.rounded}
             height={32}
             width={32}
           />
         </div>
-        <div className={styles.comment_div}>
-          <div className={styles.comment_timestamp}>
-            <b>{issue.user.login}</b> commented <Time time={issue.created_at} />
+        <div
+          className={styles.comment_div}
+        >
+          <div
+            className={
+              styles.comment_timestamp
+            }
+          >
+            <b>{issue.user.login}</b>{" "}
+            commented{" "}
+            <Time
+              time={issue.created_at}
+            />
           </div>
           <section
             dangerouslySetInnerHTML={{
               __html:
-                markdownToHtml(issue.body) || '<i>No description provided.</i>'
+                markdownToHtml(
+                  issue.body
+                ) ||
+                "<i>No description provided.</i>",
             }}
-            className={styles.comment_body}
+            className={
+              styles.comment_body
+            }
           />
         </div>
       </a>
-      {filteredComments.map((comment: Comment) => (
-        <a
-          href={comment.html_url}
-          target="_blank"
-          rel="noreferrer"
-          className={styles.comment}
-          key={comment.id}
-        >
-          <div className={styles.image}>
-            <Image
-              alt={comment.user.login}
-              src={comment.user?.avatar_url || avatar}
-              className={styles.rounded}
-              height={32}
-              width={32}
-            />
-          </div>
-          <div className={styles.comment_div}>
-            <div className={styles.comment_timestamp}>
-              <b>{comment.user.login}</b> commented{' '}
-              <Time time={comment.created_at} />
+      {filteredComments.map(
+        (comment: Comment) => (
+          <a
+            href={comment.html_url}
+            target="_blank"
+            rel="noreferrer"
+            className={styles.comment}
+            key={comment.id}
+          >
+            <div
+              className={styles.image}
+            >
+              <Image
+                alt={comment.user.login}
+                src={
+                  comment.user
+                    ?.avatar_url ||
+                  avatar
+                }
+                className={
+                  styles.rounded
+                }
+                height={32}
+                width={32}
+              />
             </div>
-            <section
-              dangerouslySetInnerHTML={{
-                __html: markdownToHtml(comment.body)
-              }}
-              className={styles.comment_body}
-            />
-          </div>
-        </a>
-      ))}
+            <div
+              className={
+                styles.comment_div
+              }
+            >
+              <div
+                className={
+                  styles.comment_timestamp
+                }
+              >
+                <b>
+                  {comment.user.login}
+                </b>{" "}
+                commented{" "}
+                <Time
+                  time={
+                    comment.created_at
+                  }
+                />
+              </div>
+              <section
+                dangerouslySetInnerHTML={{
+                  __html:
+                    markdownToHtml(
+                      comment.body
+                    ),
+                }}
+                className={
+                  styles.comment_body
+                }
+              />
+            </div>
+          </a>
+        )
+      )}
     </div>
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ const nextConfig: NextConfig = {
   experimental: {
     useCache: true,
     inlineCss: true,
-    ppr: true,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
This change removes PPR. ATM when deployed to vercel PPR will produce fallback shells for routes wiht dynamic parameters. The issue page is a dynamic parameter page and so rather than upgrading each page to a specific route shell it just continuously serves the fallback shell. However in this app's setup there is no Suspense boundary nor dynamic content and the fallback shell is empty because it accesses an unknown param. We're discussing changes to the route shell upgrade heuristic for PPR so that we can better serve this style of application automatically while not aggressively building route shells for routes with high cardinality params in them that will rarely get reused. In the meantime I'm removing PPR b/c it isn't actively being utilized for any observable purpose.

By removing PPR the page will be produced entirely statically. Unknown pages will be blockign prerenders but after the initial prerender it will be fully static for the lifetime of the deployment